### PR TITLE
AB-3716 Sync banks & clearing numbers with Bankgirot

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ Målsättningen är att stödja samtliga banker vilka är verksamma i Sverige. F
 * Swedbank
 * Ålandsbanken
 
-# Demo
-Ett demo finns tillgängligt här: [http://jop.io/projects/kontonummer-js](http://jop.io/projects/kontonummer-js)
-
 # Installation
 ```javascript
 <script src="kontonummer.min.js"></script>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Målsättningen är att stödja samtliga banker vilka är verksamma i Sverige. F
 * Nordnet Bank
 * Resurs Bank
 * Riksgälden
-* Royal Bank of Scotland
 * Santander Consumer Bank
 * SBAB
 * SEB

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Bibliotekets parserings- och valideringsregler bygger på dessa dokument:
 * [Förteckning av clering- och bankkontonummer](https://www.nordea.se/Images/39-112644/F%C3%B6rteckning%20clearing-%20och%20bankkontonummer.pdf) (Nordea)
 
 Målsättningen är att stödja samtliga banker vilka är verksamma i Sverige. För närvarande stöds följande banker:
-* Amfa Bank
 * Avanza Bank
 * BlueStep Finans
 * BNP
@@ -36,6 +35,7 @@ Målsättningen är att stödja samtliga banker vilka är verksamma i Sverige. F
 * SEB
 * Skandiabanken
 * Sparbanken Syd
+* Svea Bank
 * Swedbank
 * Ålandsbanken
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ Målsättningen är att stödja samtliga banker vilka är verksamma i Sverige. F
 * ICA Banken
 * IKANO Banken
 * JAK Medlemsbank
+* Klarna Bank
 * Landshypotek
 * Lån och Spar Bank Sverige
 * Länsförsäkringar Bank
 * Marginalen Bank
+* MedMera Bank
 * Nordax Bank
 * Nordea
 * Nordnet Bank

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -241,7 +241,7 @@
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Swedbank',
-        regex   : /^(93[0-2][0-9])/,
+        regex   : /^(93[0-4][0-9])/,
         modulo  : 10,
         lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1],
         zerofill: true

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -135,6 +135,11 @@
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
+        name    : 'Klarna Bank',
+        regex   : /^(978[0-9])/,
+        modulo  : 11,
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
+    },{
         name    : 'Landshypotek',
         regex   : /^(939[0-9])/,
         modulo  : 11,
@@ -159,6 +164,11 @@
         regex   : /^(923[0-9])/,
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
+    },{
+        name    : 'MedMera Bank',
+        regex   : /^(965[0-9])/,
+        modulo  : 11,
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Nordax Bank',
         regex   : /^(964[0-9])/,

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -205,6 +205,11 @@
         modulo  : 10,
         lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1]
     },{
+        name    : 'Riksgälden',
+        regex   : /^(988[0-9])/,
+        modulo  : 11,
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
+    },{
         name    : 'Santander Consumer Bank',
         regex   : /^(946[0-9])/,
         modulo  : 11,

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -23,332 +23,224 @@
 ;(function () {
     "use strict";
 
+    var ACCOUNT_NUMBER_TYPE = {
+        1: {
+            COMMENT: {
+                1: {
+                    clearing: 4,
+                    account: 7,
+                    control: 10
+                },
+                2: {
+                    clearing: 4,
+                    account: 7,
+                    control: 11
+                }
+            }
+        },
+        2: {
+            COMMENT: {
+                1: {
+                    clearing: 4,
+                    account: 10,
+                    control: 10
+                },
+                2: {
+                    clearing: 4,
+                    account: 9,
+                    control: 9
+                },
+                3: {
+                    clearing: 5,
+                    account: 10,
+                    control: 10
+                }
+            }
+        }
+    };
+
     var banks = [{
         name    : 'Avanza Bank',
         regex   : /^(95[5-6][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Amfa Bank',
         regex   : /^(966[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'BlueStep Finans',
         regex   : /^(968[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'BNP',
         regex   : /^(947[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Citibank',
         regex   : /^(904[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Danske Bank',
         regex   : /^(1[2-3][0-9][0-9]|24[0-9][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Danske Bank',
         regex   : /^(918[0-9])/,
         modulo  : 10,
-        lengths : {
-            clearing : 4,
-            account  : 10,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1]
     },{
         name    : 'DnB Bank',
         regex   : /^(919[0-9]|926[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Ekobanken',
         regex   : /^(970[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Erik Penser Bankaktiebolag',
         regex   : /^(959[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Forex Bank',
         regex   : /^(94[0-4][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Handelsbanken',
         regex   : /^(6[0-9][0-9][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 9,
-            control  : 9
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[2]
     },{
         name    : 'ICA Banken',
         regex   : /^(927[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'IKANO Banken',
         regex   : /^(917[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'JAK Medlemsbank',
         regex   : /^(967[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Landshypotek',
         regex   : /^(939[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Lån och Spar Bank Sverige',
         regex   : /^(963[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Länsförsäkringar Bank',
         regex   : /^(340[0-9]|906[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Länsförsäkringar Bank',
         regex   : /^(902[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Marginalen Bank',
         regex   : /^(923[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Nordax Bank',
         regex   : /^(964[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Nordea',
         regex   : /^(11[0-9][0-9]|1[4-9][0-9][0-9]|20[0-9][0-9]|3[0-2][0-9][0-9]|330[1-9]|33[1-9][0-9]|34[1-9][0-9]|3[5-9][0-9][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Nordea',
         regex   : /^(4[0-9][0-9][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Nordea',
         regex   : /^(3300|3782)/,
         modulo  : 10,
-        lengths : {
-            clearing : 4,
-            account  : 10,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1]
     },{
         name    : 'Nordnet Bank',
         regex   : /^(910[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Resurs Bank',
         regex   : /^(928[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Riksgälden',
         regex   : /^(989[0-9])/,
         modulo  : 10,
-        lengths : {
-            clearing : 4,
-            account  : 10,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1]
     },{
         name    : 'Santander Consumer Bank',
         regex   : /^(946[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'SBAB',
         regex   : /^(925[0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'SEB',
         regex   : /^(5[0-9][0-9][0-9]|912[0-4]|91[3-4][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Skandiabanken',
         regex   : /^(91[5-6][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'Sparbanken Syd',
         regex   : /^(957[0-9])/,
         modulo  : 10,
-        lengths : {
-            clearing : 4,
-            account  : 10,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1]
     },{
         name    : 'Swedbank',
         regex   : /^(7[0-9][0-9][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 10
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
         name    : 'Swedbank',
         regex   : /^(93[0-2][0-9])/,
         modulo  : 10,
-        lengths : {
-            clearing : 4,
-            account  : 10,
-            control  : 10
-        },
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1],
         zerofill: true
     },{
         name    : 'Swedbank',
         regex   : /^(8[0-9]{4})/,
         modulo  : 10,
-        lengths : {
-            clearing : 5,
-            account  : 10,
-            control  : 10
-        },
+        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[3],
         zerofill: true
     },{
         name    : 'Ålandsbanken',
         regex   : /^(23[0-9][0-9])/,
         modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     }];
 
     /**

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -6,16 +6,7 @@
  *
  * https://github.com/jop-io/kontonummer.js
  *
- * Målsättningen är att stödja samtliga banker vilka är verksamma i Sverige.
- * För närvarande stöds följande banker:
- *
- *  Amfa Bank, Avanza Bank, BlueStep Finans, BNP, Citibank, Danske Bank,
- *  DnB Bank, Ekobanken, Erik Penser Bankaktiebolag, Forex Bank, Handelsbanken,
- *  ICA Banken, IKANO Banken, JAK Medlemsbank, Landshypotek, Lån och Spar Bank
- *  Sverige, Länsförsäkringar Bank, Marginalen Bank, Nordax Bank, Nordea,
- *  Nordnet Bank, Resurs Bank, Riksgälden, Royal Bank of Scotland, Santander
- *  Consumer Bank, SBAB, SEB, Skandiabanken, Sparbanken Syd, Swedbank,
- *  Ålandsbanken
+ * Målsättningen är att stödja samtliga banker som är verksamma i Sverige.
  *
  * Licens: MIT
  * Författare: @jop-io

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -65,10 +65,10 @@
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
-        name    : 'Amfa Bank',
+        name    : 'Svea Bank',
         regex   : /^(966[0-9])/,
         modulo  : 11,
-        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
+        lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
         name    : 'BlueStep Finans',
         regex   : /^(968[0-9])/,

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -267,15 +267,6 @@
             control  : 10
         }
     },{
-        name    : 'Royal Bank of Scotland',
-        regex   : /^(909[0-9])/,
-        modulo  : 11,
-        lengths : {
-            clearing : 4,
-            account  : 7,
-            control  : 11
-        }
-    },{
         name    : 'Santander Consumer Bank',
         regex   : /^(946[0-9])/,
         modulo  : 11,

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -75,7 +75,7 @@
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]
     },{
-        name    : 'BNP',
+        name    : 'BNP Paribas',
         regex   : /^(947[0-9])/,
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
@@ -95,7 +95,7 @@
         modulo  : 10,
         lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[1]
     },{
-        name    : 'DnB Bank',
+        name    : 'DNB Bank',
         regex   : /^(919[0-9]|926[0-9])/,
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
@@ -105,7 +105,7 @@
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
-        name    : 'Erik Penser Bankaktiebolag',
+        name    : 'Erik Penser',
         regex   : /^(959[0-9])/,
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
@@ -145,7 +145,7 @@
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[2]
     },{
-        name    : 'Lån och Spar Bank Sverige',
+        name    : 'Lån & Spar Bank Sverige',
         regex   : /^(963[0-9])/,
         modulo  : 11,
         lengths : ACCOUNT_NUMBER_TYPE[1].COMMENT[1]

--- a/kontonummer.js
+++ b/kontonummer.js
@@ -18,7 +18,7 @@
  *  Ålandsbanken
  *
  * Licens: MIT
- * Författare: @jop-io, http://jop.io
+ * Författare: @jop-io
  */
 ;(function () {
     "use strict";

--- a/tests/kontonummer.js
+++ b/tests/kontonummer.js
@@ -193,7 +193,7 @@ describe('Kontonummer suite', () => {
     });
 
     it('should not throw on String argument passed', () => {
-      const fakeAccountNumber = '90917261730';
+      const fakeAccountNumber = '91800123456782';
       const result = kontonummer(fakeAccountNumber);
 
       chai.assert.isTrue(


### PR DESCRIPTION
This aims to synchronize the clearing number and account number validation with the latest version (`2019-10-22`) of the ["Bank Account Numbers in Swedish Banks" manual](https://www.bankgirot.se/globalassets/dokument/anvandarmanualer/bankernaskontonummeruppbyggnad_anvandarmanual_sv.pdf) from Bankgirot.

It **adds** `Klarna Bank` & `MedMera Bank`, **removes** the `Royal Bank of Scotland` and **updates** the clearing number ranges for `Riksgälden` and `Swedbank`. It also **renames** `Amfa Bank` to `Svea Bank` and improves the spelling of some other bank names.

This also adds CI through [Github Actions](https://github.com/features/actions), since that was quick and simple to do and will help ensure all tests pass for PRs. As part of this the `master` branch has been protected to require a PR, review, successful tests & commit message linting before merges to `master`.

AB-3716