### PR TITLE
AB-3845 Add warning state for swedbank

### DIFF
--- a/kontonummer.js
+++ b/kontonummer.js
@@ -240,7 +240,7 @@
         name    : 'Swedbank',
         regex   : /^(8[0-9]{4})/,
         modulo  : 10,
-        lengths : ACCOUNT_NUMBER_TYPE[2].COMMENT[3],
+        lengths : Object.assign({}, ACCOUNT_NUMBER_TYPE[2].COMMENT[3],{ min_account: 6 }),
         zerofill: true,
         warnOnBadChecksum: true // Special swedbank accounts can cause checksum errors which we conditionally want to suppress
     },{
@@ -310,13 +310,24 @@
         };
     };
 
-    var validateLength = function(bank, bankNumber) {
+    var removeNumberZeroPadding = function(numberAsString) {
+        return String(parseInt(numberAsString, 10));
+    }
+
+    var validateLength = function(bank, normalizedBankAccountNumber) {
         var errors = [];
 
-        if (bank.regex.test(bankNumber)) {
-            if (bankNumber.length < bank.lengths.clearing + bank.lengths.account) {
+        if (bank.regex.test(normalizedBankAccountNumber)) {
+            var minBankNumberLength = bank.lengths.clearing + bank.lengths.account;
+            var maxBankNumberLength = bank.lengths.clearing + bank.lengths.account;
+            var accountNumber = getAccountNumber(normalizedBankAccountNumber, bank.lengths.clearing);
+            var significantAccountNumber = removeNumberZeroPadding(accountNumber);
+
+            if (bank.lengths.min_account && significantAccountNumber.length < bank.lengths.min_account) {
                 errors.push('too_short');
-            } else if (bankNumber.length > bank.lengths.clearing + bank.lengths.account) {
+            } else if (normalizedBankAccountNumber.length < minBankNumberLength) {
+                errors.push('too_short');
+            } else if (normalizedBankAccountNumber.length > maxBankNumberLength) {
                 errors.push('too_long');
             }
         }

--- a/tests/kontonummer.js
+++ b/tests/kontonummer.js
@@ -179,6 +179,28 @@ describe('Kontonummer suite', () => {
       const expected = ['too_long'];
       chai.assert.deepEqual(expected, result);
     });
+
+
+    it('should return object with warning too_short for Swedbank with min_account', () => {
+      const mockBankSwedbank = {
+        name    : 'Swedbank',
+        regex   : /^(8[0-9]{4})/,
+        modulo  : 10,
+        lengths : {
+          clearing : 5,
+          account  : 10,
+          control  : 10,
+          min_account: 6,
+        },
+        zerofill: true,
+        warnOnBadChecksum: true,
+      };
+      const fakeAccountNumber = '8002123452';
+      const result = kontonummer._validateLength(mockBankSwedbank, fakeAccountNumber);
+
+      const expected = ['too_short'];
+      chai.assert.deepEqual(expected, result);
+    });
   });
 
   describe('mod10()', () => {
@@ -285,6 +307,14 @@ describe('Kontonummer suite', () => {
         kontonummer('800212345212358'),
         {
           has_warnings: true,
+        }
+      );
+    });
+    it('should return object with errors too_short on a swedbank account with short account length', () => {
+      chai.assert.deepInclude(
+        kontonummer('800212345').matched_banks[0],
+        {
+          errors: [ 'too_short' ],
         }
       );
     });

--- a/tests/kontonummer.js
+++ b/tests/kontonummer.js
@@ -103,6 +103,7 @@ describe('Kontonummer suite', () => {
         bank_name: 'Citibank',
         clearing_number: '9044',
         account_number: '123456789',
+        warnings: [],
       };
       const result = kontonummer._validateChecksum(mockBank, fakeAccountNumber);
 
@@ -116,11 +117,39 @@ describe('Kontonummer suite', () => {
         bank_name: 'Citibank',
         clearing_number: '9044',
         account_number: '12345',
+        warnings: [],
       };
       const result = kontonummer._validateChecksum(mockBank, fakeAccountNumber);
 
       chai.assert.deepEqual(expected, result);
     });
+
+    it('should return object with warning bad_checksum for Swedbank', () => {
+      const mockBankSwedbank = {
+        name    : 'Swedbank',
+        regex   : /^(8[0-9]{4})/,
+        modulo  : 10,
+        lengths : {
+          clearing : 5,
+          account  : 10,
+          control  : 10
+        },
+        zerofill: true,
+        warnOnBadChecksum: true,
+      };
+      const fakeAccountNumber = '800212345212358';
+      const expected = {
+        errors: [],
+        bank_name: 'Swedbank',
+        clearing_number: '80021',
+        account_number: '2345212358',
+        warnings: ['bad_checksum'],
+      };
+      const result = kontonummer._validateChecksum(mockBankSwedbank, fakeAccountNumber);
+
+      chai.assert.deepEqual(expected, result);
+    });
+
   });
 
   describe('validateLength()', () => {
@@ -187,7 +216,8 @@ describe('Kontonummer suite', () => {
         {
           is_valid: false,
           errors: ['invalid_account_number'],
-          matched_banks: []
+          matched_banks: [],
+          has_warnings: false,
         }
       );
     });
@@ -208,7 +238,8 @@ describe('Kontonummer suite', () => {
         {
           is_valid: false,
           errors: ['invalid_account_number'],
-          matched_banks: []
+          matched_banks: [],
+          has_warnings: false,
         }
       );
       chai.assert.deepEqual(
@@ -216,7 +247,8 @@ describe('Kontonummer suite', () => {
         {
           is_valid: false,
           errors: ['invalid_account_number'],
-          matched_banks: []
+          matched_banks: [],
+          has_warnings: false,
         }
       );
       chai.assert.deepEqual(
@@ -224,7 +256,8 @@ describe('Kontonummer suite', () => {
         {
           is_valid: false,
           errors: ['invalid_account_number'],
-          matched_banks: []
+          matched_banks: [],
+          has_warnings: false,
         }
       );
       chai.assert.deepEqual(
@@ -232,7 +265,8 @@ describe('Kontonummer suite', () => {
         {
           is_valid: false,
           errors: ['invalid_account_number'],
-          matched_banks: []
+          matched_banks: [],
+          has_warnings: false,
         }
       );
       chai.assert.deepEqual(
@@ -240,7 +274,17 @@ describe('Kontonummer suite', () => {
         {
           is_valid: false,
           errors: ['invalid_account_number'],
-          matched_banks: []
+          matched_banks: [],
+          has_warnings: false,
+        }
+      );
+    });
+
+    it('should return object with has_warnings true on a swedbank account with invalid checksum', () => {
+      chai.assert.include(
+        kontonummer('800212345212358'),
+        {
+          has_warnings: true,
         }
       );
     });


### PR DESCRIPTION
Since some special cases with Swedbank accounts with specific clearing
numbers occurs that will break checksum check and give false negatives
these errors are suppressed as warnings instead of errors. The function
will return these account numbers as valid with a warning flag and a
warning array on the bank object.

AB-3845